### PR TITLE
[add]未認証時に認証メール+メール確認しろページに遷移

### DIFF
--- a/src/components/FirebaseAuthProvider.tsx
+++ b/src/components/FirebaseAuthProvider.tsx
@@ -15,7 +15,7 @@ const FirebaseAuthProvider = (props: Props) => {
 
   useEffect(() => {
     const unsubscribed = auth.onAuthStateChanged((new_user: User | null) => {
-      if (new_user) {
+      if (new_user && new_user.emailVerified) {
         setUser(new_user);
       } else {
         setUser(null);

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -4,7 +4,8 @@ import { VStack, Text, Box } from "@chakra-ui/react";
 import { Input, InputGroup, InputRightElement } from "@chakra-ui/react";
 import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton } from "@chakra-ui/react";
 import { useToast } from "@chakra-ui/react";
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import { getAuth, signInWithEmailAndPassword, sendEmailVerification } from "firebase/auth";
+import { useRouter } from "next/router";
 import { useState } from "react";
 
 interface Props {
@@ -20,6 +21,7 @@ const LoginModal = (props: Props) => {
   const [email, setEmail] = useState("");
   const [loginPass, setLoginPass] = useState("");
   const auth = getAuth();
+  const router = useRouter();
 
   const toast = useToast();
   const onSigninBtnClicked = () => {
@@ -36,6 +38,12 @@ const LoginModal = (props: Props) => {
         setEmail("");
         setLoginPass("");
         props.onClose();
+        if (auth.currentUser && !auth.currentUser.emailVerified) {
+          sendEmailVerification(auth.currentUser).then(() => {
+            console.log("認証メールを送りました。");
+            router.push("/waitEmailVerify");
+          });
+        }
       })
       .catch((err) => {
         console.log(err);

--- a/src/components/SignupModal.tsx
+++ b/src/components/SignupModal.tsx
@@ -4,7 +4,8 @@ import { VStack, Text, Box } from "@chakra-ui/react";
 import { Input, InputGroup, InputRightElement } from "@chakra-ui/react";
 import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton } from "@chakra-ui/react";
 import { useToast } from "@chakra-ui/react";
-import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+import { getAuth, createUserWithEmailAndPassword, sendEmailVerification } from "firebase/auth";
+import { useRouter } from "next/router";
 import { useState } from "react";
 
 interface Props {
@@ -20,6 +21,7 @@ const SignupModal = (props: Props) => {
   const [email, setEmail] = useState("");
   const [loginPass, setLoginPass] = useState("");
   const auth = getAuth();
+  const router = useRouter();
 
   const toast = useToast();
   const onSignupBtnClicked = () => {
@@ -36,6 +38,12 @@ const SignupModal = (props: Props) => {
         setEmail("");
         setLoginPass("");
         props.onClose();
+        if (auth.currentUser && !auth.currentUser.emailVerified) {
+          sendEmailVerification(auth.currentUser).then(() => {
+            console.log("認証メールを送りました。");
+            router.push("/waitEmailVerify");
+          });
+        }
       })
       .catch((err) => {
         console.log(err);

--- a/src/pages/firebaseTest.tsx
+++ b/src/pages/firebaseTest.tsx
@@ -1,8 +1,9 @@
 import { Box, Button, Text, Flex, Image, useColorMode, useColorModeValue } from "@chakra-ui/react";
-import { getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
+import { getAuth, signInWithEmailAndPassword, signOut, sendEmailVerification } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { collection, doc, addDoc, getDocs, updateDoc, deleteDoc } from "firebase/firestore";
 import { getStorage, ref, getDownloadURL, uploadBytes } from "firebase/storage";
+import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { theme } from "./_app";
@@ -113,6 +114,27 @@ const FirebaseTestPage = () => {
     }
   };
 
+  const emailVerification = () => {
+    if (auth.currentUser) {
+      sendEmailVerification(auth.currentUser).then(() => {
+        console.log("uwaaaaa");
+      });
+    }
+  };
+  const showIsVerificated = () => {
+    if (auth.currentUser) {
+      console.log(auth.currentUser.emailVerified);
+    }
+  };
+
+  const router = useRouter();
+  const goToRoot = () => {
+    if (auth.currentUser) {
+      console.log(auth.currentUser.emailVerified);
+      router.push("/");
+    }
+  };
+
   return (
     <Box>
       <Box>
@@ -125,6 +147,8 @@ const FirebaseTestPage = () => {
         <Image id='myimg' src='' alt='代替テキスト' />
       </Box>
       <Button>hoge</Button>
+      <Button onClick={showIsVerificated}>showVerificated</Button>
+      <Button onClick={emailVerification}>verificationdayo</Button>
       <Button onClick={LoginWithEmailAndPass}>Logindayo</Button>
       <Button onClick={signoutUser}>signoutDayo</Button>
       <Button onClick={addData}>addData</Button>
@@ -132,6 +156,7 @@ const FirebaseTestPage = () => {
       <Button onClick={getData}>GetData</Button>
       <Button onClick={updateData}>UpdateData</Button>
       <Button onClick={getImgURL}>getImgURL</Button>
+      <Button onClick={goToRoot}>GoToRoot</Button>
       <input name='file' type='file' accept='image/*' onChange={onChangeFile} />
       <Button onClick={submitFile}>送信</Button>
       <Flex align='center' gap={2}>

--- a/src/pages/waitEmailVerify.tsx
+++ b/src/pages/waitEmailVerify.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, Text, useColorMode, useColorModeValue } from "@chakra-ui/react";
+import Link from "next/link";
+
+import { theme } from "./_app";
+
+const EmailConfirmPage = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+  const secondary = useColorModeValue(theme.colors.secondary.ml, theme.colors.secondary.md);
+
+  return (
+    <Box>
+      <Box>
+        <p>Current color mode: {colorMode}</p>
+        <Button onClick={() => console.log("eeeee")}>Change color mode</Button>
+      </Box>
+      <Text>アカウントのメアドに認証メールのリンク投げたのでメアド認証しろ!!!</Text>
+      <Link href='/'>
+        <Text>indexへ</Text>
+      </Link>
+    </Box>
+  );
+};
+
+export default EmailConfirmPage;


### PR DESCRIPTION
・LoginModal.tsxおよびSignupModal.tsxを変更しメールアドレスが未認証のユーザーがログイン/もしくは新しくユーザーを作成した時、メールアドレス認証メールを送付し、メアド認証しろページ(waitEmailVerify.tsx)に遷移するようにした。
