### PR TITLE
Feature/#115 dm logic

### DIFF
--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -19,7 +19,6 @@ import useSWR from "swr";
 
 import DMInteractor from "@/interactors/DM/DMInteractor";
 import { DMDataWithRelativeData, DMMessageCreateData, DMMessageDataWithRelativeData } from "@/interactors/DM/DMTypes";
-import { UserPublicData } from "@/interactors/User/UserTypes";
 
 import { FirebaseAuthContext } from "./FirebaseAuthProvider";
 
@@ -151,24 +150,26 @@ const DMModal = (props: Props) => {
     let MyUserID = user ? user.id : "unreachable";
     let titleUserName = user ? user.name : "unreachable";
     //console.log(MyUserID + ":" + titleUserName);
-
-    dmData.members.forEach((aMember: UserPublicData) => {
+    for (let i = 0; i < dmData.members.length; i++) {
+      const aMember = dmData.members[i];
       if (aMember.id != MyUserID) {
         titleUserName = aMember.name;
+        return titleUserName;
       }
-    });
+    }
     return titleUserName;
   };
-  const GetDMImage = (dmData: DMDataWithRelativeData) => {
+  const GetDMImage = (dmData: DMDataWithRelativeData): string => {
     let MyUserID = user ? user.id : "unreachable";
     let thumbnailURL = user ? (user.icon ? user.icon : "https://bit.ly/dan-abramov") : "unreachable";
-
-    dmData.members.forEach((aMember: UserPublicData) => {
+    for (let i = 0; i < dmData.members.length; i++) {
+      const aMember = dmData.members[i];
       if (aMember.id != MyUserID && aMember.icon) {
         thumbnailURL = aMember.icon;
+        return thumbnailURL;
       }
-      return thumbnailURL;
-    });
+    }
+    return thumbnailURL;
   };
 
   let ButtonsToDM_Node = <></>;

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -127,15 +127,8 @@ const DMModal = (props: Props) => {
 
   const ButtonToDM = (dmData: DMDataWithRelativeData) => {
     let MyUserID = user ? user.id : "unreachable";
-    let thumbnailURL = user ? (user.icon ? user.icon : "https://bit.ly/dan-abramov") : "unreachable";
-    let titleUserName = user ? user.name : "unreachable";
-
-    dmData.members.forEach((aMember: UserPublicData) => {
-      if (aMember.id != MyUserID && aMember.icon) {
-        thumbnailURL = aMember.icon;
-        titleUserName = aMember.name;
-      }
-    });
+    const thumbnailURL = GetDMImage(dmData);
+    const titleUserName = GetDMTitle(dmData);
 
     return (
       <Box
@@ -152,6 +145,29 @@ const DMModal = (props: Props) => {
         </Flex>
       </Box>
     );
+  };
+
+  const GetDMTitle = (dmData: DMDataWithRelativeData) => {
+    let MyUserID = user ? user.id : "unreachable";
+    let titleUserName = user ? user.name : "unreachable";
+
+    dmData.members.forEach((aMember: UserPublicData) => {
+      if (aMember.id != MyUserID && aMember.icon) {
+        titleUserName = aMember.name;
+      }
+    });
+    return titleUserName;
+  };
+  const GetDMImage = (dmData: DMDataWithRelativeData) => {
+    let MyUserID = user ? user.id : "unreachable";
+    let thumbnailURL = user ? (user.icon ? user.icon : "https://bit.ly/dan-abramov") : "unreachable";
+
+    dmData.members.forEach((aMember: UserPublicData) => {
+      if (aMember.id != MyUserID && aMember.icon) {
+        thumbnailURL = aMember.icon;
+      }
+      return thumbnailURL;
+    });
   };
 
   let ButtonsToDM_Node = <></>;
@@ -191,14 +207,14 @@ const DMModal = (props: Props) => {
       {isMessageOpen && (
         <Box overflowY='hidden' w='320px' h='calc(100vh - 50px)' bg='gray' p={4}>
           <CloseButton onClick={() => setIsMessageOpen(false)} />
-          <Text fontSize='3xl'>user name</Text>
+          <Text fontSize='3xl'>{OpeningDM ? GetDMTitle(OpeningDM) : "user name"}</Text>
           <Flex direction='column' h='100%'>
             <Stack flex={0.85} overflowY='scroll' ref={chatAreaRef}>
               <>
                 {
                   <Box borderWidth='1px'>
-                    {CurrentDispMessages.map((message, index) => (
-                      <Flex key={index} justify={user && message.sender.id === user.id ? "left" : "right"} p='1'>
+                    {CurrentDispMessages.map((message, index) => {
+                      const imagePart = (
                         <Image
                           p='1'
                           borderRadius='full'
@@ -206,11 +222,29 @@ const DMModal = (props: Props) => {
                           src={message.sender.icon ? message.sender.icon : "https://bit.ly/dan-abramov"}
                           alt='User Icon'
                         />
+                      );
+                      const textPart = (
                         <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
                           {message.content}
                         </Text>
-                      </Flex>
-                    )).reverse()}
+                      );
+                      const isMyMessage = user && message.sender.id === user.id;
+                      return (
+                        <Flex key={index} justify={isMyMessage ? "left" : "right"} p='1'>
+                          {isMyMessage ? (
+                            <>
+                              {imagePart}
+                              {textPart}
+                            </>
+                          ) : (
+                            <>
+                              {textPart}
+                              {imagePart}
+                            </>
+                          )}
+                        </Flex>
+                      );
+                    }).reverse()}
                   </Box>
                 }
               </>

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -55,13 +55,17 @@ const DMModal = (props: Props) => {
     data: MyDMDatas,
     error: DMError,
     isLoading: DMLoading,
-  } = useSWR(`/DM/${user ? user.id : "None"}`, async () => {
-    if (user) {
-      return await interactor.getWithMemberID_DM(user.id);
-    } else {
-      return [];
-    }
-  });
+  } = useSWR(
+    `/DM/${user ? user.id : "None"}`,
+    async () => {
+      if (user) {
+        return await interactor.getWithMemberID_DM(user.id);
+      } else {
+        return [];
+      }
+    },
+    { refreshInterval: 10000 }
+  );
 
   const [isMessageOpen, setIsMessageOpen] = useState<boolean>(false);
 

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -54,8 +54,8 @@ const DMModal = (props: Props) => {
 
   const {
     data: MyDMDatas,
-    error,
-    isLoading,
+    error: DMError,
+    isLoading: DMLoading,
   } = useSWR(`/DM/${user ? user.id : "None"}`, async () => {
     if (user) {
       return await interactor.getWithMemberID_DM(user.id);
@@ -74,10 +74,31 @@ const DMModal = (props: Props) => {
 
   const [messages, setMessages] = useState<Message["contents"][]>([]); // メッセージのリスト
   const [newMessage, setNewMessage] = useState(""); // 新しいメッセージの入力値
+
+  const {
+    data: DMMessages,
+    error: DMMessageError,
+    isLoading: DMMessageLoading,
+  } = useSWR(`/DMMessage/${OpeningDM ? OpeningDM.id : "None"}`, async () => {
+    if (OpeningDM) {
+      return await interactor.getLatests_DMMessage(OpeningDM.id, 30);
+    } else {
+      return [];
+    }
+  });
+
   // 新しいメッセージを送信する関数
   const sendMessage = () => {
     if (newMessage.trim()) {
-      setMessages((prevMessages) => [...prevMessages, newMessage]);
+      if (OpeningDM && user) {
+        const createData: DMMessageCreateData = {
+          content: newMessage,
+          sender_id: user.id,
+        };
+        interactor.set_DMMessage(OpeningDM?.id, createData);
+      } else {
+        console.log("unreachable!");
+      }
       setNewMessage(""); // 入力フィールドをクリア
     }
   };
@@ -118,7 +139,7 @@ const DMModal = (props: Props) => {
       >
         <Flex>
           <Image borderRadius='full' boxSize='30px' src={thumbnailURL} alt='User Icon' />
-          <Text fontSize='md'> user name</Text>
+          <Text fontSize='md'> {titleUserName}</Text>
         </Flex>
       </Box>
     );
@@ -144,93 +165,14 @@ const DMModal = (props: Props) => {
             }}
           >
             <motion.div animate='open' exit='closed'>
-              <Card p='4' bg='tomato' variant='outline'>
+              <Card minHeight='100%' p='4' bg='tomato' variant='outline'>
                 <CloseButton onClick={() => props.onClose()} />
                 <CardHeader>
                   <Heading size='xl'>Direct Message</Heading>
                 </CardHeader>
 
                 <CardBody>
-                  <Stack spacing='4'>
-                    <Box bg='black' p='4' onClick={() => setIsMessageOpen(true)}>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='black' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                    <Box bg='blue' p='4'>
-                      <Flex>
-                        <Image borderRadius='full' boxSize='30px' src='https://bit.ly/dan-abramov' alt='User Icon' />
-                        <Text fontSize='md'> user name</Text>
-                      </Flex>
-                    </Box>
-                  </Stack>
+                  <Stack spacing='4'>{ButtonsToDM_Node}</Stack>
                 </CardBody>
               </Card>
             </motion.div>
@@ -246,37 +188,39 @@ const DMModal = (props: Props) => {
               <>
                 {changeUserID == true ? (
                   <Box borderWidth='1px'>
-                    {messages.map((message, index) => (
-                      <Flex key={index} justify='right' p='1'>
-                        <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
-                          {message}
-                        </Text>
-                        <Image
-                          p='1'
-                          borderRadius='full'
-                          boxSize='40px'
-                          src='https://bit.ly/dan-abramov'
-                          alt='User Icon'
-                        />
-                      </Flex>
-                    ))}
+                    {DMMessages &&
+                      DMMessages.map((message, index) => (
+                        <Flex key={index} justify='left' p='1'>
+                          <Image
+                            p='1'
+                            borderRadius='full'
+                            boxSize='40px'
+                            src={message.sender.icon ? message.sender.icon : "https://bit.ly/dan-abramov"}
+                            alt='User Icon'
+                          />
+                          <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
+                            {message.content}
+                          </Text>
+                        </Flex>
+                      )).reverse()}
                   </Box>
                 ) : (
                   <Box borderWidth='1px'>
-                    {messages.map((message, index) => (
-                      <Flex key={index} justify='left' p='1'>
-                        <Image
-                          p='1'
-                          borderRadius='full'
-                          boxSize='40px'
-                          src='https://bit.ly/dan-abramov'
-                          alt='User Icon'
-                        />
-                        <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
-                          {message}
-                        </Text>
-                      </Flex>
-                    ))}
+                    {DMMessages &&
+                      DMMessages.map((message, index) => (
+                        <Flex key={index} justify='left' p='1'>
+                          <Image
+                            p='1'
+                            borderRadius='full'
+                            boxSize='40px'
+                            src={message.sender.icon ? message.sender.icon : "https://bit.ly/dan-abramov"}
+                            alt='User Icon'
+                          />
+                          <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
+                            {message.content}
+                          </Text>
+                        </Flex>
+                      )).reverse()}
                   </Box>
                 )}
               </>

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -127,7 +127,7 @@ const DMModal = (props: Props) => {
 
   const ButtonToDM = (dmData: DMDataWithRelativeData) => {
     let MyUserID = user ? user.id : "unreachable";
-    const thumbnailURL = GetDMImage(dmData);
+    const thumbnailURL: string = GetDMImage(dmData);
     const titleUserName = GetDMTitle(dmData);
 
     return (
@@ -150,9 +150,10 @@ const DMModal = (props: Props) => {
   const GetDMTitle = (dmData: DMDataWithRelativeData) => {
     let MyUserID = user ? user.id : "unreachable";
     let titleUserName = user ? user.name : "unreachable";
+    //console.log(MyUserID + ":" + titleUserName);
 
     dmData.members.forEach((aMember: UserPublicData) => {
-      if (aMember.id != MyUserID && aMember.icon) {
+      if (aMember.id != MyUserID) {
         titleUserName = aMember.name;
       }
     });
@@ -258,7 +259,13 @@ const DMModal = (props: Props) => {
                 color='tomato'
                 _placeholder={{ color: "tomato" }}
               />
-              <Button colorScheme='blue' ml={2} onClick={() => sendMessage}>
+              <Button
+                colorScheme='blue'
+                ml={2}
+                onClick={() => {
+                  sendMessage();
+                }}
+              >
                 送信
               </Button>
             </Flex>

--- a/src/components/DMModal.tsx
+++ b/src/components/DMModal.tsx
@@ -67,9 +67,6 @@ const DMModal = (props: Props) => {
   const [isMessageOpen, setIsMessageOpen] = useState<boolean>(false);
 
   const [OpeningDM, setOpeningDM] = useState<DMDataWithRelativeData | null>(null);
-
-  const [changeUserID, setChangeUserID] = useState<boolean>(false);
-
   const chatAreaRef = useRef<HTMLDivElement | null>(null);
 
   const [newMessage, setNewMessage] = useState(""); // 新しいメッセージの入力値
@@ -198,10 +195,10 @@ const DMModal = (props: Props) => {
           <Flex direction='column' h='100%'>
             <Stack flex={0.85} overflowY='scroll' ref={chatAreaRef}>
               <>
-                {changeUserID == true ? (
+                {
                   <Box borderWidth='1px'>
                     {CurrentDispMessages.map((message, index) => (
-                      <Flex key={index} justify='left' p='1'>
+                      <Flex key={index} justify={user && message.sender.id === user.id ? "left" : "right"} p='1'>
                         <Image
                           p='1'
                           borderRadius='full'
@@ -215,24 +212,7 @@ const DMModal = (props: Props) => {
                       </Flex>
                     )).reverse()}
                   </Box>
-                ) : (
-                  <Box borderWidth='1px'>
-                    {CurrentDispMessages.map((message, index) => (
-                      <Flex key={index} justify='left' p='1'>
-                        <Image
-                          p='1'
-                          borderRadius='full'
-                          boxSize='40px'
-                          src={message.sender.icon ? message.sender.icon : "https://bit.ly/dan-abramov"}
-                          alt='User Icon'
-                        />
-                        <Text bg='blue.100' p='2' borderRadius='md' w='60%'>
-                          {message.content}
-                        </Text>
-                      </Flex>
-                    )).reverse()}
-                  </Box>
-                )}
+                }
               </>
             </Stack>
             <Flex mt={15} top='50' borderRadius='full' bg='white'>
@@ -244,7 +224,7 @@ const DMModal = (props: Props) => {
                 color='tomato'
                 _placeholder={{ color: "tomato" }}
               />
-              <Button colorScheme='blue' ml={2} onClick={() => setChangeUserID(!changeUserID)}>
+              <Button colorScheme='blue' ml={2} onClick={() => sendMessage}>
                 送信
               </Button>
             </Flex>

--- a/src/interactors/BaseInteractor.ts
+++ b/src/interactors/BaseInteractor.ts
@@ -98,7 +98,8 @@ export default class BaseInteractor {
     collection_name: string,
     sub_path: string[],
     limitNum: number,
-    startId: string | null = null
+    startId: string | null = null,
+    isCacheUsed: boolean = true
   ): Promise<Array<DocumentData> | null> {
     try {
       const collectionRef = collection(this.db, collection_name, ...sub_path);
@@ -110,9 +111,11 @@ export default class BaseInteractor {
       const q = query(collectionRef, ...queryConstraints);
 
       const cacheKey = `getSub/${collection_name}/${sub_path.join("/")}/${limitNum}/${startId ? startId : "head"}`;
-      const cache = window.sessionStorage.getItem(cacheKey);
-      if (cache) {
-        return JSON.parse(cache);
+      if (isCacheUsed) {
+        const cache = window.sessionStorage.getItem(cacheKey);
+        if (cache) {
+          return JSON.parse(cache);
+        }
       }
 
       const snapshot = await getDocs(q);

--- a/src/interactors/DM/DMInteractor.ts
+++ b/src/interactors/DM/DMInteractor.ts
@@ -1,0 +1,53 @@
+//import ArtworkMapper from "./ArtworkMapper";
+import { DMCreateData, DMMessageCreateData } from "./DMTypes";
+import { FilterArg } from "../BaseInteractor";
+import BaseInteractor from "../BaseInteractor";
+
+export default class DMInteractor {
+  readonly interactor: BaseInteractor;
+  readonly COLLECTION_NAME = "DMs";
+  readonly SUBCOLLECTION_NAME = "Messages";
+  constructor() {
+    this.interactor = new BaseInteractor();
+  }
+
+  //DM-----------------------------
+
+  async get_DM(DM_id: string) {
+    return await this.interactor.get(this.COLLECTION_NAME, DM_id);
+  }
+
+  async set_DM(data: DMCreateData) {
+    await this.interactor.set(this.COLLECTION_NAME, this.interactor.uuidv4(), data);
+  }
+
+  //ユーザ-がメンバーとなっているDMを全て取得
+  async getWithMemberID_DM(userId: string) {
+    const filter: FilterArg = { key: "member_ids", operator: "array-contains", value: userId };
+    return await this.interactor.FilterAnd("DMs", [filter]);
+  }
+
+  async getLatests_DM(limit: number, startId: string | null = null) {
+    return await this.interactor.getLatests("DMs", limit, startId);
+  }
+
+  //DMMessage-------------------------------
+  async get_DMMessage(DM_id: string, DMMessage_id: string) {
+    return await this.interactor.getSubCollection(this.COLLECTION_NAME, [DM_id, this.SUBCOLLECTION_NAME], DMMessage_id);
+  }
+  async set_DMMessage(DM_id: string, data: DMMessageCreateData) {
+    return await this.interactor.setSubCollection(
+      this.COLLECTION_NAME,
+      [DM_id, this.SUBCOLLECTION_NAME],
+      this.interactor.uuidv4(),
+      data
+    );
+  }
+
+  //DMのメッセージを全て取得
+  async getLatests_DMMessage(DM_id: string, limitNum: number, startId: string | null = null) {
+    return await this.interactor.getSubCollections("DMs", [DM_id, this.SUBCOLLECTION_NAME], limitNum, startId);
+  }
+
+  async makeDM() {}
+}

--- a/src/interactors/DM/DMInteractor.ts
+++ b/src/interactors/DM/DMInteractor.ts
@@ -31,6 +31,9 @@ export default class DMInteractor {
       return null;
     }
   }
+  async delete_DM(DM_id: string) {
+    await this.interactor.delete(this.COLLECTION_NAME, DM_id);
+  }
 
   //ユーザ-がメンバーとなっているDMを全て取得
   async getWithMemberID_DM(userId: string) {

--- a/src/interactors/DM/DMInteractor.ts
+++ b/src/interactors/DM/DMInteractor.ts
@@ -99,7 +99,8 @@ export default class DMInteractor {
       "DMs",
       [DM_id, this.SUBCOLLECTION_NAME],
       limitNum,
-      startId
+      startId,
+      false
     );
     if (docDatas) {
       let retData: DMMessageDataWithRelativeData[] = [];

--- a/src/interactors/DM/DMInteractor.ts
+++ b/src/interactors/DM/DMInteractor.ts
@@ -1,5 +1,6 @@
 //import ArtworkMapper from "./ArtworkMapper";
-import { DMCreateData, DMMessageCreateData } from "./DMTypes";
+import DMMapper from "./DMMapper";
+import { DMCreateData, DMDataWithRelativeData, DMMessageCreateData, DMMessageDataWithRelativeData } from "./DMTypes";
 import { FilterArg } from "../BaseInteractor";
 import BaseInteractor from "../BaseInteractor";
 
@@ -13,40 +14,105 @@ export default class DMInteractor {
 
   //DM-----------------------------
 
-  async get_DM(DM_id: string) {
-    return await this.interactor.get(this.COLLECTION_NAME, DM_id);
+  async get_DM(DM_id: string): Promise<null | DMDataWithRelativeData> {
+    const docData = await this.interactor.get(this.COLLECTION_NAME, DM_id);
+    if (docData) {
+      return DMMapper.mapDocDataToDMDataWithRelativeData(docData);
+    } else {
+      return null;
+    }
   }
 
-  async set_DM(data: DMCreateData) {
-    await this.interactor.set(this.COLLECTION_NAME, this.interactor.uuidv4(), data);
+  async set_DM(data: DMCreateData): Promise<null | DMDataWithRelativeData> {
+    const docData = await this.interactor.set(this.COLLECTION_NAME, this.interactor.uuidv4(), data);
+    if (docData) {
+      return DMMapper.mapDocDataToDMDataWithRelativeData(docData);
+    } else {
+      return null;
+    }
   }
 
   //ユーザ-がメンバーとなっているDMを全て取得
   async getWithMemberID_DM(userId: string) {
     const filter: FilterArg = { key: "member_ids", operator: "array-contains", value: userId };
-    return await this.interactor.FilterAnd("DMs", [filter]);
+    const docDatas = await this.interactor.FilterAnd("DMs", [filter]);
+    if (docDatas) {
+      let retData: DMDataWithRelativeData[] = [];
+      for (let i = 0; i < docDatas.length; i++) {
+        const mappedData = await DMMapper.mapDocDataToDMDataWithRelativeData(docDatas[i]);
+        if (mappedData) {
+          retData.push(mappedData);
+        }
+      }
+      return retData;
+    } else {
+      return null;
+    }
   }
 
   async getLatests_DM(limit: number, startId: string | null = null) {
-    return await this.interactor.getLatests("DMs", limit, startId);
+    const docDatas = await this.interactor.getLatests("DMs", limit, startId);
+    if (docDatas) {
+      let retData: DMDataWithRelativeData[] = [];
+      for (let i = 0; i < docDatas.length; i++) {
+        const mappedData = await DMMapper.mapDocDataToDMDataWithRelativeData(docDatas[i]);
+        if (mappedData) {
+          retData.push(mappedData);
+        }
+      }
+      return retData;
+    } else {
+      return null;
+    }
   }
 
   //DMMessage-------------------------------
   async get_DMMessage(DM_id: string, DMMessage_id: string) {
-    return await this.interactor.getSubCollection(this.COLLECTION_NAME, [DM_id, this.SUBCOLLECTION_NAME], DMMessage_id);
+    const docData = await this.interactor.getSubCollection(
+      this.COLLECTION_NAME,
+      [DM_id, this.SUBCOLLECTION_NAME],
+      DMMessage_id
+    );
+    if (docData) {
+      return await DMMapper.mapDocDataToDMMessageDataWithRelativeData(docData);
+    } else {
+      return null;
+    }
   }
   async set_DMMessage(DM_id: string, data: DMMessageCreateData) {
-    return await this.interactor.setSubCollection(
+    const docData = await this.interactor.setSubCollection(
       this.COLLECTION_NAME,
       [DM_id, this.SUBCOLLECTION_NAME],
       this.interactor.uuidv4(),
       data
     );
+    if (docData) {
+      return await DMMapper.mapDocDataToDMMessageDataWithRelativeData(docData);
+    } else {
+      return null;
+    }
   }
 
   //DMのメッセージを全て取得
   async getLatests_DMMessage(DM_id: string, limitNum: number, startId: string | null = null) {
-    return await this.interactor.getSubCollections("DMs", [DM_id, this.SUBCOLLECTION_NAME], limitNum, startId);
+    const docDatas = await this.interactor.getSubCollections(
+      "DMs",
+      [DM_id, this.SUBCOLLECTION_NAME],
+      limitNum,
+      startId
+    );
+    if (docDatas) {
+      let retData: DMMessageDataWithRelativeData[] = [];
+      for (let i = 0; i < docDatas.length; i++) {
+        const mappedData = await DMMapper.mapDocDataToDMMessageDataWithRelativeData(docDatas[i]);
+        if (mappedData) {
+          retData.push(mappedData);
+        }
+      }
+      return retData;
+    } else {
+      return null;
+    }
   }
 
   async makeDM() {}

--- a/src/interactors/DM/DMMapper.ts
+++ b/src/interactors/DM/DMMapper.ts
@@ -1,0 +1,74 @@
+import { DocumentData } from "@firebase/firestore";
+
+import { ArtworkData, ArtworkDataWithRelativeData } from "@/interactors/Artwork/ArtworkTypes";
+import FileInteractor from "@/interactors/File/FileInteractor";
+
+import ArtworkInteractor from "../Artwork/ArtworkInteractor";
+import CommentInteractor from "../Comment/CommentInteractor";
+import UserInteractor from "../User/UserInteractor";
+
+export default class DMMapper {
+  static async mapDocDataToDMData(data: DocumentData): Promise<ArtworkData | null> {
+    const file_data = await new FileInteractor().get(data.file_id);
+    if (!file_data) return null;
+    return {
+      id: data.id,
+      type: data.type,
+      name: data.name,
+      description: data.description,
+      file: file_data,
+      view_num: data.view_num,
+      save_num: data.save_num,
+      uploaded: new Date(data.uploaded),
+      is_public: data.is_public || false, // TODO: 無理やり設定するのをやめる
+
+      author_id: data.author_id,
+      tags: data.tags,
+      comment_ids: data.comment_ids,
+      parent_ids: data.parent_ids,
+
+      created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
+      updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
+    };
+  }
+
+  static async mapDocDataToDMDataWithRelativeData(data: DocumentData): Promise<ArtworkDataWithRelativeData | null> {
+    const file_data = await new FileInteractor().get(data.file_id);
+    const user_data = await new UserInteractor().getPublicData(data.author_id);
+    if (!file_data || !user_data) return null;
+
+    const comment_interactor = new CommentInteractor();
+    const comment_data_list = [];
+    for (let i = 0; i < data.comment_ids.length; i++) {
+      const comment_data = await comment_interactor.get(data.comment_ids[i]);
+      if (comment_data !== null) comment_data_list.push(comment_data);
+    }
+
+    const artwork_interactor = new ArtworkInteractor();
+    const artwork_data_list = [];
+    for (let i = 0; i < data.parent_ids.length; i++) {
+      const artwork_data = await artwork_interactor.get(data.parent_ids[i]);
+      if (artwork_data !== null) artwork_data_list.push(artwork_data);
+    }
+
+    return {
+      id: data.id,
+      type: data.type,
+      name: data.name,
+      description: data.description,
+      file: file_data,
+      view_num: data.view_num,
+      save_num: data.save_num,
+      uploaded: new Date(data.uploaded),
+      is_public: data.is_public || false, // TODO: 無理やり設定するのをやめる
+
+      author: user_data,
+      tags: data.tags,
+      comments: comment_data_list,
+      parents: artwork_data_list,
+
+      created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
+      updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
+    };
+  }
+}

--- a/src/interactors/DM/DMMapper.ts
+++ b/src/interactors/DM/DMMapper.ts
@@ -30,8 +30,8 @@ export default class DMMapper {
       id: data.id,
       name: data.name,
       members: members_data,
-      created_at: data.create_data,
-      updated_at: data.update_at,
+      created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
+      updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
     };
   }
 
@@ -58,8 +58,8 @@ export default class DMMapper {
       id: data.id,
       content: data.content,
       sender: sender_data,
-      created_at: data.create_data,
-      updated_at: data.update_at,
+      created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
+      updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
     };
   }
 }

--- a/src/interactors/DM/DMMapper.ts
+++ b/src/interactors/DM/DMMapper.ts
@@ -1,74 +1,60 @@
 import { DocumentData } from "@firebase/firestore";
 
-import { ArtworkData, ArtworkDataWithRelativeData } from "@/interactors/Artwork/ArtworkTypes";
-import FileInteractor from "@/interactors/File/FileInteractor";
-
-import ArtworkInteractor from "../Artwork/ArtworkInteractor";
-import CommentInteractor from "../Comment/CommentInteractor";
+import { DMData, DMDataWithRelativeData, DMMessageData, DMMessageDataWithRelativeData } from "../DM/DMTypes";
 import UserInteractor from "../User/UserInteractor";
+import { UserPublicData } from "../User/UserTypes";
 
 export default class DMMapper {
-  static async mapDocDataToDMData(data: DocumentData): Promise<ArtworkData | null> {
-    const file_data = await new FileInteractor().get(data.file_id);
-    if (!file_data) return null;
+  static mapDocDataToDMData(data: DocumentData): DMData {
     return {
       id: data.id,
-      type: data.type,
       name: data.name,
-      description: data.description,
-      file: file_data,
-      view_num: data.view_num,
-      save_num: data.save_num,
-      uploaded: new Date(data.uploaded),
-      is_public: data.is_public || false, // TODO: 無理やり設定するのをやめる
-
-      author_id: data.author_id,
-      tags: data.tags,
-      comment_ids: data.comment_ids,
-      parent_ids: data.parent_ids,
+      member_ids: data.member_ids,
 
       created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
       updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
     };
   }
 
-  static async mapDocDataToDMDataWithRelativeData(data: DocumentData): Promise<ArtworkDataWithRelativeData | null> {
-    const file_data = await new FileInteractor().get(data.file_id);
-    const user_data = await new UserInteractor().getPublicData(data.author_id);
-    if (!file_data || !user_data) return null;
-
-    const comment_interactor = new CommentInteractor();
-    const comment_data_list = [];
-    for (let i = 0; i < data.comment_ids.length; i++) {
-      const comment_data = await comment_interactor.get(data.comment_ids[i]);
-      if (comment_data !== null) comment_data_list.push(comment_data);
-    }
-
-    const artwork_interactor = new ArtworkInteractor();
-    const artwork_data_list = [];
-    for (let i = 0; i < data.parent_ids.length; i++) {
-      const artwork_data = await artwork_interactor.get(data.parent_ids[i]);
-      if (artwork_data !== null) artwork_data_list.push(artwork_data);
-    }
-
+  static async mapDocDataToDMDataWithRelativeData(data: DocumentData): Promise<DMDataWithRelativeData | null> {
+    const interactor = new UserInteractor();
+    const members_data: UserPublicData[] = await data.member_ids.map((aID: string) => {
+      return interactor.getPublicData(aID);
+    });
     return {
       id: data.id,
-      type: data.type,
       name: data.name,
-      description: data.description,
-      file: file_data,
-      view_num: data.view_num,
-      save_num: data.save_num,
-      uploaded: new Date(data.uploaded),
-      is_public: data.is_public || false, // TODO: 無理やり設定するのをやめる
+      members: members_data,
+      created_at: data.create_data,
+      updated_at: data.update_at,
+    };
+  }
 
-      author: user_data,
-      tags: data.tags,
-      comments: comment_data_list,
-      parents: artwork_data_list,
+  static mapDocDataToDMMessageData(data: DocumentData): DMMessageData {
+    return {
+      id: data.id,
+      content: data.content,
+      sender_id: data.sender_id,
 
       created_at: data.created_at.toDate ? new Date(data.created_at.toDate()) : new Date(),
       updated_at: data.updated_at.toDate ? new Date(data.updated_at.toDate()) : new Date(),
+    };
+  }
+
+  static async mapDocDataToDMMessageDataWithRelativeData(
+    data: DocumentData
+  ): Promise<DMMessageDataWithRelativeData | null> {
+    const interactor = new UserInteractor();
+    const sender_data: UserPublicData | null = await interactor.getPublicData(data.sender_id);
+    if (!sender_data) {
+      return null;
+    }
+    return {
+      id: data.id,
+      content: data.content,
+      sender: sender_data,
+      created_at: data.create_data,
+      updated_at: data.update_at,
     };
   }
 }

--- a/src/interactors/DM/DMMapper.ts
+++ b/src/interactors/DM/DMMapper.ts
@@ -19,7 +19,7 @@ export default class DMMapper {
   static async mapDocDataToDMDataWithRelativeData(data: DocumentData): Promise<DMDataWithRelativeData | null> {
     const interactor = new UserInteractor();
     let members_data: UserPublicData[] = [];
-    console.log(data.member_ids.length);
+    //console.log(data.member_ids.length);
     for (let i = 0; i < data.member_ids.length; i++) {
       const member_pubData = await interactor.getPublicData(data.member_ids[i]);
       if (member_pubData) {

--- a/src/interactors/DM/DMMapper.ts
+++ b/src/interactors/DM/DMMapper.ts
@@ -18,9 +18,14 @@ export default class DMMapper {
 
   static async mapDocDataToDMDataWithRelativeData(data: DocumentData): Promise<DMDataWithRelativeData | null> {
     const interactor = new UserInteractor();
-    const members_data: UserPublicData[] = await data.member_ids.map((aID: string) => {
-      return interactor.getPublicData(aID);
-    });
+    let members_data: UserPublicData[] = [];
+    console.log(data.member_ids.length);
+    for (let i = 0; i < data.member_ids.length; i++) {
+      const member_pubData = await interactor.getPublicData(data.member_ids[i]);
+      if (member_pubData) {
+        members_data.push(member_pubData);
+      }
+    }
     return {
       id: data.id,
       name: data.name,

--- a/src/interactors/DM/DMTypes.ts
+++ b/src/interactors/DM/DMTypes.ts
@@ -1,7 +1,14 @@
 import { BaseModel } from "../BaseTypes";
 import { UserPublicData } from "../User/UserTypes";
 
+//DM--------------------------------
 export interface DMData extends BaseModel {
+  id: string;
+  name: string;
+  member_ids: string[];
+}
+
+export interface DMDataWithRelativeData extends BaseModel {
   id: string;
   name: string;
   members: UserPublicData[];
@@ -12,7 +19,14 @@ export interface DMCreateData {
   member_ids: string[];
 }
 
+//DMMessage--------------------------------
 export interface DMMessageData extends BaseModel {
+  id: string;
+  content: string;
+  sender_id: string;
+}
+
+export interface DMMessageDataWithRelativeData extends BaseModel {
   id: string;
   content: string;
   sender: UserPublicData;

--- a/src/interactors/DM/DMTypes.ts
+++ b/src/interactors/DM/DMTypes.ts
@@ -1,0 +1,24 @@
+import { BaseModel } from "../BaseTypes";
+import { UserPublicData } from "../User/UserTypes";
+
+export interface DMData extends BaseModel {
+  id: string;
+  name: string;
+  members: UserPublicData[];
+}
+
+export interface DMCreateData {
+  name: string;
+  member_ids: string[];
+}
+
+export interface DMMessageData extends BaseModel {
+  id: string;
+  content: string;
+  sender: UserPublicData;
+}
+
+export interface DMMessageCreateData {
+  content: string;
+  sender_id: string;
+}

--- a/src/pages/UserInteractorTest.tsx
+++ b/src/pages/UserInteractorTest.tsx
@@ -18,6 +18,7 @@ const FirebaseTestPage = () => {
   const [contentInput, setContentInput] = useState("");
   const [dmMembersInput, setDMMembersInput] = useState("");
   const [dmNameInput, setDMNameInput] = useState("");
+  const [DMdom, setDMdom] = useState<ReactNode>(<></>);
 
   const secondary = useColorModeValue(theme.colors.secondary.ml, theme.colors.secondary.md);
 
@@ -52,11 +53,34 @@ const FirebaseTestPage = () => {
   };
 
   const getDMs = async () => {
-    console.log(await new DMInteractor().getLatests_DM(10));
+    const data = await new DMInteractor().getLatests_DM(10);
+    console.log(data);
+    if (data) {
+      let nextDom = <></>;
+
+      for (let i = 0; i < data.length; i++) {
+        const DMMessages = await new DMInteractor().getLatests_DMMessage(data[i].id, 20);
+        nextDom = (
+          <>
+            {nextDom}
+            <Box key='ss' border={"8px"} padding={"8px"}>
+              <Text key={data[i].id}>{`${data[i].id}`}</Text>
+              <Text key={data[i].id}>{`member:${data[i].members.map((aData) => aData.id)}`}</Text>
+              <Text key={data[i].id}>{`name:${data[i].name}`}</Text>
+              <Text>
+                {DMMessages?.map((aData) => aData.content + `(${aData.sender.id} : ${aData.created_at})` + "<=")}
+              </Text>
+            </Box>
+          </>
+        );
+      }
+      setDMdom(nextDom);
+    }
   };
 
   const GetDMMessage = async (): Promise<void> => {
     const interactor: DMInteractor = new DMInteractor();
+
     console.log(await interactor.getLatests_DMMessage(DMIDInput, 20));
   };
 
@@ -118,6 +142,7 @@ const FirebaseTestPage = () => {
       </Flex>
       <Button onClick={addDM}>addDM</Button>
       <Button onClick={getDMs}>getDM</Button>
+      {DMdom}
     </Box>
   );
 };

--- a/src/pages/UserInteractorTest.tsx
+++ b/src/pages/UserInteractorTest.tsx
@@ -77,6 +77,9 @@ const FirebaseTestPage = () => {
       setDMdom(nextDom);
     }
   };
+  const deleteDM = async () => {
+    await new DMInteractor().delete_DM(DMIDInput);
+  };
 
   const GetDMMessage = async (): Promise<void> => {
     const interactor: DMInteractor = new DMInteractor();
@@ -118,6 +121,7 @@ const FirebaseTestPage = () => {
       </Flex>
 
       <Button onClick={addDMMessage}>addMessage</Button>
+      <Button onClick={deleteDM}>deleteDM</Button>
       <Box margin='50px'></Box>
       <Flex>
         <Text width={"200px"}>DMの名前</Text>

--- a/src/pages/UserInteractorTest.tsx
+++ b/src/pages/UserInteractorTest.tsx
@@ -1,9 +1,6 @@
-import { Box, Button, Text, Image, useColorMode, useColorModeValue } from "@chakra-ui/react";
-import { getAuth, signInWithEmailAndPassword, signOut, sendEmailVerification } from "firebase/auth";
+import { Box, Button, useColorModeValue, Input, Text, Flex } from "@chakra-ui/react";
+import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
-import { collection, doc, getDocs, updateDoc, deleteDoc } from "firebase/firestore";
-import { getStorage, ref, getDownloadURL, uploadBytes } from "firebase/storage";
-import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { FilterArg } from "@/interactors/BaseInteractor";
@@ -16,8 +13,11 @@ import { theme } from "./_app";
 const FirebaseTestPage = () => {
   const auth = getAuth();
   const db = getFirestore();
-  const { colorMode, toggleColorMode } = useColorMode();
-  const [count, setCount] = useState<number>(0);
+  const [DMIDInput, setDMIDInput] = useState("");
+  const [senderIDInput, setSenderIDInput] = useState("");
+  const [contentInput, setContentInput] = useState("");
+  const [dmMembersInput, setDMMembersInput] = useState("");
+  const [dmNameInput, setDMNameInput] = useState("");
 
   const secondary = useColorModeValue(theme.colors.secondary.ml, theme.colors.secondary.md);
 
@@ -34,152 +34,90 @@ const FirebaseTestPage = () => {
     console.log(await interactor.getSubCollections("DMs", ["o8S50pCLAIcpOtl6cGtj", "Comments"], 100));
   };
 
-  const signoutUser = () => {
-    signOut(auth)
-      .then(() => {
-        console.log("サインアウトしたよ~");
-      })
-      .catch((error) => {
-        // An error happened.
-      });
-  };
-
-  const LoginWithEmailAndPass = () => {
-    signInWithEmailAndPassword(auth, "toktabea@gmail.com", "xp2800ch")
-      .then((userCredential) => {
-        // Signed in
-        const user = userCredential.user;
-        console.log("ログインしたよ");
-        console.log(user.displayName + "/" + user.email + "/" + user.uid + "/" + user.getIdToken());
-        // ...
-      })
-      .catch((error) => {
-        const errorCode = error.code;
-        const errorMessage = error.message;
-      });
-  };
-
   const addDM = async (): Promise<void> => {
+    const members = dmMembersInput.split("/");
     const interactor: DMInteractor = new DMInteractor();
-    const createData: DMCreateData = { name: "DMだよ!", member_ids: [] };
+    const createData: DMCreateData = { name: dmNameInput, member_ids: members };
     await interactor.set_DM(createData);
-    console.log("つくったよ");
+    console.log("DMを新規作成");
   };
   const addDMMessage = async (): Promise<void> => {
     const interactor: DMInteractor = new DMInteractor();
     const createData: DMMessageCreateData = {
-      sender_id: "fKlgkoss0nNWYamOJkMuLxOWGEW2",
-      content: "よろしくお願いします",
+      sender_id: senderIDInput,
+      content: contentInput,
     };
-    await interactor.set_DMMessage("d753e91f-7afb-4da1-8547-09d8e6d67d23", createData);
+    await interactor.set_DMMessage(DMIDInput, createData);
     console.log("おくったよ");
   };
-  const getData = async (): Promise<void> => {
-    const querySnapshot = await getDocs(collection(db, "users"));
-    querySnapshot.forEach((doc) => {
-      console.log(`${doc.id} => ${JSON.stringify(doc.data())}`);
-    });
-  };
-  const updateData = async (): Promise<void> => {
-    const docRef = doc(db, "users", "bvJup5fhaPXLPgJlduhr");
-    // Set the "capital" field of the city 'DC'
-    await updateDoc(docRef, {
-      bornDif: true,
-    });
+
+  const getDMs = async () => {
+    console.log(await new DMInteractor().getLatests_DM(10));
   };
 
-  const deleteData = async (): Promise<void> => {
-    await deleteDoc(doc(db, "users", "bvJup5fhaPXLPgJlduhr"));
-    console.log("DataDeleted");
-  };
-
-  const uploadPicture = async (): Promise<void> => {
-    // Create a root reference
-    const storage = getStorage();
-
-    // Create a reference to 'images/mountains.jpg'
-    const mountainImagesRef = ref(storage, "images/mountains.jpg");
-
-    const metadata = {
-      contentType: "image/jpeg",
-    };
-  };
-
-  const getImgURL = async (): Promise<void> => {
-    const storage = getStorage();
-    getDownloadURL(ref(storage, "bib.jpg")).then((url) => {
-      console.log(url);
-      const img = document.getElementById("myimg");
-      if (img) {
-        img.setAttribute("src", url);
-      }
-    });
-  };
-  const [file, setFile] = useState<File | null>(null);
-  const onChangeFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (files && files[0]) {
-      setFile(files[0]);
-    }
-  };
-
-  const submitFile = () => {
-    if (file) {
-      const storage = getStorage();
-      const storageRef = ref(storage, file.name);
-      uploadBytes(storageRef, file).then((snapshot) => {
-        console.log("Uploaded a blob or file!");
-      });
-    } else {
-      console.log("file is not selected");
-    }
-  };
-
-  const emailVerification = () => {
-    if (auth.currentUser) {
-      sendEmailVerification(auth.currentUser).then(() => {
-        console.log("uwaaaaa");
-      });
-    }
-  };
-  const showIsVerificated = () => {
-    if (auth.currentUser) {
-      console.log(auth.currentUser.emailVerified);
-    }
-  };
-
-  const router = useRouter();
-  const goToRoot = () => {
-    if (auth.currentUser) {
-      console.log(auth.currentUser.emailVerified);
-      router.push("/");
-    }
+  const GetDMMessage = async (): Promise<void> => {
+    const interactor: DMInteractor = new DMInteractor();
+    console.log(await interactor.getLatests_DMMessage(DMIDInput, 20));
   };
 
   return (
     <Box>
-      <Box>
-        <p>Current color mode: {colorMode}</p>
-        <Button onClick={toggleColorMode}>Change color mode</Button>
-      </Box>
-      <Text color={secondary}>hoge</Text>
-      <Box bg={secondary} w='100px' h='100px'></Box>
-      <Box bg={secondary} w='100px' h='100px'>
-        <Image id='myimg' src='' alt='代替テキスト' />
-      </Box>
-      <Button onClick={hoge_func}>hoge</Button>
-      <Button onClick={showIsVerificated}>showVerificated</Button>
-      <Button onClick={emailVerification}>verificationdayo</Button>
-      <Button onClick={LoginWithEmailAndPass}>Logindayo</Button>
-      <Button onClick={signoutUser}>signoutDayo</Button>
-      <Button onClick={addDM}>addDM</Button>
-      <Button onClick={addDMMessage}>addMessage</Button>
+      <Flex>
+        <Text width={"200px"}>DMのID</Text>
+        <Input
+          id='name'
+          type='text'
+          onChange={(e) => {
+            setDMIDInput(e.target.value);
+          }}
+        />
+      </Flex>
+      <Flex>
+        <Text width={"200px"}>送信者のID</Text>
+        <Input
+          id='name'
+          type='text'
+          onChange={(e) => {
+            setSenderIDInput(e.target.value);
+          }}
+        />
+      </Flex>
+      <Flex>
+        <Text width={"200px"}>送信内容</Text>
+        <Input
+          id='name'
+          type='text'
+          onChange={(e) => {
+            setContentInput(e.target.value);
+          }}
+        />
+      </Flex>
 
-      <Button onClick={deleteData}>deleteData</Button>
-      <Button onClick={getData}>GetData</Button>
-      <Button onClick={updateData}>UpdateData</Button>
-      <input name='file' type='file' accept='image/*' onChange={onChangeFile} />
-      <Button onClick={submitFile}>送信</Button>
+      <Button onClick={addDMMessage}>addMessage</Button>
+      <Button onClick={GetDMMessage}>GetMessage</Button>
+      <Box margin='50px'></Box>
+      <Flex>
+        <Text width={"200px"}>DMの名前</Text>
+        <Input
+          id='name'
+          type='text'
+          onChange={(e) => {
+            setDMNameInput(e.target.value);
+          }}
+        />
+      </Flex>
+      <Flex>
+        <Text width={"200px"}>DMのメンバーのID</Text>
+        <Input
+          id='name'
+          type='text'
+          onChange={(e) => {
+            setDMMembersInput(e.target.value);
+          }}
+        />
+      </Flex>
+      <Button onClick={addDM}>addDM</Button>
+      <Button onClick={getDMs}>getDM</Button>
     </Box>
   );
 };

--- a/src/pages/UserInteractorTest.tsx
+++ b/src/pages/UserInteractorTest.tsx
@@ -118,7 +118,6 @@ const FirebaseTestPage = () => {
       </Flex>
 
       <Button onClick={addDMMessage}>addMessage</Button>
-      <Button onClick={GetDMMessage}>GetMessage</Button>
       <Box margin='50px'></Box>
       <Flex>
         <Text width={"200px"}>DMの名前</Text>

--- a/src/pages/UserInteractorTest.tsx
+++ b/src/pages/UserInteractorTest.tsx
@@ -1,0 +1,187 @@
+import { Box, Button, Text, Image, useColorMode, useColorModeValue } from "@chakra-ui/react";
+import { getAuth, signInWithEmailAndPassword, signOut, sendEmailVerification } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+import { collection, doc, getDocs, updateDoc, deleteDoc } from "firebase/firestore";
+import { getStorage, ref, getDownloadURL, uploadBytes } from "firebase/storage";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import { FilterArg } from "@/interactors/BaseInteractor";
+import BaseInteractor from "@/interactors/BaseInteractor";
+import DMInteractor from "@/interactors/DM/DMInteractor";
+import { DMCreateData, DMMessageCreateData } from "@/interactors/DM/DMTypes";
+
+import { theme } from "./_app";
+
+const FirebaseTestPage = () => {
+  const auth = getAuth();
+  const db = getFirestore();
+  const { colorMode, toggleColorMode } = useColorMode();
+  const [count, setCount] = useState<number>(0);
+
+  const secondary = useColorModeValue(theme.colors.secondary.ml, theme.colors.secondary.md);
+
+  const hoge_func = async () => {
+    console.log("nnnnnnnnn");
+    const interactor = new BaseInteractor();
+    const dminteractor = new DMInteractor();
+    //console.log(await interactor.get("o8S50pCLAIcpOtl6cGtj"));
+    //const fddd: FilterArg = { key: "tags", operator: "array-contains", value: "temple" };
+    //console.log(await interactor.FilterAnd("artworks", [fddd]));
+    const fddd: FilterArg = { key: "member_ids", operator: "array-contains", value: "fKlgkoss0nNWYamOJkMuLxOWGEW2" };
+    //console.log(await interactor.FilterAnd("DMs", [fddd]));
+    console.log(await dminteractor.getWithMemberID_DM("fKlgkoss0nNWYamOJkMuLxOWGEW2"));
+    console.log(await interactor.getSubCollections("DMs", ["o8S50pCLAIcpOtl6cGtj", "Comments"], 100));
+  };
+
+  const signoutUser = () => {
+    signOut(auth)
+      .then(() => {
+        console.log("サインアウトしたよ~");
+      })
+      .catch((error) => {
+        // An error happened.
+      });
+  };
+
+  const LoginWithEmailAndPass = () => {
+    signInWithEmailAndPassword(auth, "toktabea@gmail.com", "xp2800ch")
+      .then((userCredential) => {
+        // Signed in
+        const user = userCredential.user;
+        console.log("ログインしたよ");
+        console.log(user.displayName + "/" + user.email + "/" + user.uid + "/" + user.getIdToken());
+        // ...
+      })
+      .catch((error) => {
+        const errorCode = error.code;
+        const errorMessage = error.message;
+      });
+  };
+
+  const addDM = async (): Promise<void> => {
+    const interactor: DMInteractor = new DMInteractor();
+    const createData: DMCreateData = { name: "DMだよ!", member_ids: [] };
+    await interactor.set_DM(createData);
+    console.log("つくったよ");
+  };
+  const addDMMessage = async (): Promise<void> => {
+    const interactor: DMInteractor = new DMInteractor();
+    const createData: DMMessageCreateData = {
+      sender_id: "fKlgkoss0nNWYamOJkMuLxOWGEW2",
+      content: "よろしくお願いします",
+    };
+    await interactor.set_DMMessage("d753e91f-7afb-4da1-8547-09d8e6d67d23", createData);
+    console.log("おくったよ");
+  };
+  const getData = async (): Promise<void> => {
+    const querySnapshot = await getDocs(collection(db, "users"));
+    querySnapshot.forEach((doc) => {
+      console.log(`${doc.id} => ${JSON.stringify(doc.data())}`);
+    });
+  };
+  const updateData = async (): Promise<void> => {
+    const docRef = doc(db, "users", "bvJup5fhaPXLPgJlduhr");
+    // Set the "capital" field of the city 'DC'
+    await updateDoc(docRef, {
+      bornDif: true,
+    });
+  };
+
+  const deleteData = async (): Promise<void> => {
+    await deleteDoc(doc(db, "users", "bvJup5fhaPXLPgJlduhr"));
+    console.log("DataDeleted");
+  };
+
+  const uploadPicture = async (): Promise<void> => {
+    // Create a root reference
+    const storage = getStorage();
+
+    // Create a reference to 'images/mountains.jpg'
+    const mountainImagesRef = ref(storage, "images/mountains.jpg");
+
+    const metadata = {
+      contentType: "image/jpeg",
+    };
+  };
+
+  const getImgURL = async (): Promise<void> => {
+    const storage = getStorage();
+    getDownloadURL(ref(storage, "bib.jpg")).then((url) => {
+      console.log(url);
+      const img = document.getElementById("myimg");
+      if (img) {
+        img.setAttribute("src", url);
+      }
+    });
+  };
+  const [file, setFile] = useState<File | null>(null);
+  const onChangeFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files[0]) {
+      setFile(files[0]);
+    }
+  };
+
+  const submitFile = () => {
+    if (file) {
+      const storage = getStorage();
+      const storageRef = ref(storage, file.name);
+      uploadBytes(storageRef, file).then((snapshot) => {
+        console.log("Uploaded a blob or file!");
+      });
+    } else {
+      console.log("file is not selected");
+    }
+  };
+
+  const emailVerification = () => {
+    if (auth.currentUser) {
+      sendEmailVerification(auth.currentUser).then(() => {
+        console.log("uwaaaaa");
+      });
+    }
+  };
+  const showIsVerificated = () => {
+    if (auth.currentUser) {
+      console.log(auth.currentUser.emailVerified);
+    }
+  };
+
+  const router = useRouter();
+  const goToRoot = () => {
+    if (auth.currentUser) {
+      console.log(auth.currentUser.emailVerified);
+      router.push("/");
+    }
+  };
+
+  return (
+    <Box>
+      <Box>
+        <p>Current color mode: {colorMode}</p>
+        <Button onClick={toggleColorMode}>Change color mode</Button>
+      </Box>
+      <Text color={secondary}>hoge</Text>
+      <Box bg={secondary} w='100px' h='100px'></Box>
+      <Box bg={secondary} w='100px' h='100px'>
+        <Image id='myimg' src='' alt='代替テキスト' />
+      </Box>
+      <Button onClick={hoge_func}>hoge</Button>
+      <Button onClick={showIsVerificated}>showVerificated</Button>
+      <Button onClick={emailVerification}>verificationdayo</Button>
+      <Button onClick={LoginWithEmailAndPass}>Logindayo</Button>
+      <Button onClick={signoutUser}>signoutDayo</Button>
+      <Button onClick={addDM}>addDM</Button>
+      <Button onClick={addDMMessage}>addMessage</Button>
+
+      <Button onClick={deleteData}>deleteData</Button>
+      <Button onClick={getData}>GetData</Button>
+      <Button onClick={updateData}>UpdateData</Button>
+      <input name='file' type='file' accept='image/*' onChange={onChangeFile} />
+      <Button onClick={submitFile}>送信</Button>
+    </Box>
+  );
+};
+
+export default FirebaseTestPage;


### PR DESCRIPTION
DMのロジックができた。

やれること
・DMモーダルから自分が参加しているDMを見れる。
・そのDMに投稿された内容が見れる。
・DMに文字メッセージを送れる
・リアルタイムに他のユーザーがDMに送った内容を確認できる。
・/usersにDM作成ボタンを作り、それを押すと、自分とそのユーザーとのDMが作成される。

・一時的に作った/UserInteractorTestというページのgetDMボタンを押すと、現在データベース上に存在する全てのDMの情報を表示できる。
・/UserInteractorTestというページの「DMのID」というボックスにDMのIDを入力してdeleteDMボタンを押すと、DMを削除できる

やれないこと
・公開用の通常のページからのDMの削除

バグ?
・DMModalのチャット画面で、ひらがなを入力している時などにエンターキーを押すと、ひらがなの変換がされるとともに、それがメッセージとして投稿されてしまう。(エンターキーを使えなくしてもいいなら、onKeyDownを消せば無くせそう)
・DMModalのDMの一覧を表示している画面で、DMの数が少なすぎると、DM一覧の後ろにある緑色の要素が見えてしまう。(これは直し方が分からなかった。)

